### PR TITLE
KBV-394 Add encrypted DDB tables to core infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .aws-sam/
 *.iml
+samconfig.toml

--- a/core/deploy.sh
+++ b/core/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+sam validate
+sam build --config-env dev
+sam deploy --config-env dev --no-fail-on-empty-changeset

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -38,6 +38,8 @@ Resources:
           Value: "true"
         - Key: "awsStackName"
           Value: !Sub "${AWS::StackName}"
+        - Key: "CheckovRulesToSkip"
+          Value: "CKV_AWS_7"
 
   CriDecryptionKey1:
     Type: AWS::KMS::Key
@@ -61,12 +63,20 @@ Resources:
           Value: "true"
         - Key: "awsStackName"
           Value: !Sub "${AWS::StackName}"
+        - Key: "CheckovRulesToSkip"
+          Value: "CKV_AWS_7"
 
   SessionTable1:
     Type: "AWS::DynamoDB::Table"
     Properties:
       TableName: !Sub "${AWS::StackName}-session1"
       BillingMode: "PAY_PER_REQUEST"
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        KMSMasterKeyId: !Ref ResourceEncryptionKmsKey1
+        SSEEnabled: true
+        SSEType: "KMS"
       AttributeDefinitions:
         - AttributeName: "sessionId"
           AttributeType: "S"
@@ -107,6 +117,32 @@ Resources:
       Description: Api key 1
       Enabled: true
 
+  ResourceEncryptionKmsKey1:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+          - Effect: Allow
+            Principal:
+              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+            Condition:
+              ArnLike:
+                "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+
   ApiKey2:
     Type: AWS::ApiGateway::ApiKey
     Properties:
@@ -144,6 +180,18 @@ Outputs:
     Value: !GetAtt CriDecryptionKey1.Arn
     Export:
       Name: !Sub ${AWS::StackName}-CriDecryptionKey1Arn
+
+  ResourceEncryptionKmsKey1Id:
+    Description: "CRI KMS Decryption Key 1 Id"
+    Value: !Ref ResourceEncryptionKmsKey1
+    Export:
+      Name: !Sub ${AWS::StackName}-ResourceEncryptionKmsKey1Id
+
+  ResourceEncryptionKmsKey1Arn:
+    Description: "CRI KMS Decryption Key 1 Arn"
+    Value: !GetAtt ResourceEncryptionKmsKey1.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ResourceEncryptionKmsKey1Arn
 
   ApiKey1:
     Description: "API key 1 for API Gateway"

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -108,7 +108,28 @@ Resources:
               - "subject"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
-        AttributeName: expiry-date
+        AttributeName: expiryDate
+        Enabled: true
+
+  PersonIdentityTable1:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: !Sub "person-identity-${AWS::StackName}"
+      BillingMode: "PAY_PER_REQUEST"
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        KMSMasterKeyId: !Ref ResourceEncryptionKmsKey1
+        SSEEnabled: true
+        SSEType: "KMS"
+      AttributeDefinitions:
+        - AttributeName: "sessionId"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "sessionId"
+          KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: expiryDate
         Enabled: true
 
   ApiKey1:
@@ -156,6 +177,12 @@ Outputs:
     Value: !Ref SessionTable1
     Export:
       Name: !Sub ${AWS::StackName}-TableNameSession1
+
+  TableNamePersonIdentity1:
+    Description: "DynamoDB Person Identity Table Name"
+    Value: !Ref PersonIdentityTable1
+    Export:
+      Name: !Sub ${AWS::StackName}-TableNamePersonIdentity1
 
   CriVcSigningKey1Id:
     Description: "CRI KMS Signing Key 1 Id"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

* Add a common symmetric encryption key so that we can use one per AWS account
* Add a user attributes table that can be encrypted at rest with above key
* Allow session table to use this key too
* Export these stack resources so they can be imported into API stacks
* Apply checkov checks to common infra in the same manner as https://github.com/alphagov/di-ipv-cri-address-api/pull/117


- [KBV-394](https://govukverify.atlassian.net/browse/KBV-394)
