### PR TITLE
[KBV-398] Add VPC stacks for address CRI

### DIFF
--- a/templates/manual/README.md
+++ b/templates/manual/README.md
@@ -1,0 +1,18 @@
+The templates in this directory are not deployed via any pipelines.
+
+Run up the new CRI VPC which is using temporarily assigned EIP's.
+
+```shell
+  gds aws di-ipv-cri-address-<ENVIRONMENT> -- aws cloudformation create-stack \
+  --stack-name cri-vpc --template-body file://./cri-vpc.yaml \
+  --capabilities CAPABILITY_AUTO_EXPAND 
+```
+
+
+To update the cri-vpc stack
+
+```shell
+  gds aws di-ipv-cri-address-<ENVIRONMENT> -- aws cloudformation update-stack \
+  --stack-name cri-vpc --template-body file://./cri-vpc.yaml \
+  --capabilities CAPABILITY_AUTO_EXPAND 
+```

--- a/templates/manual/cri-vpc.yaml
+++ b/templates/manual/cri-vpc.yaml
@@ -1,0 +1,281 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: |
+  This CloudFormation template deploys a basic VPC / Network including the IP's for whitelisting.
+
+Parameters:
+
+  VpcCIDR:
+    Description: Please enter the IP range (CIDR notation) for this VPC
+    Type: String
+    Default: 10.1.0.0/16
+
+  PublicSubnetACIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the first Availability Zone
+    Type: String
+    Default: 10.1.10.0/24
+
+  PublicSubnetBCIDR:
+    Description: Please enter the IP range (CIDR notation) for the public subnet in the second Availability Zone
+    Type: String
+    Default: 10.1.20.0/24
+
+  PrivateSubnetACIDR:
+    Description: Please enter the IP range (CIDR notation) for the private subnet in the first Availability Zone
+    Type: String
+    Default: 10.1.50.0/24
+
+  PrivateSubnetBCIDR:
+    Description: Please enter the IP range (CIDR notation) for the private subnet in the second Availability Zone
+    Type: String
+    Default: 10.1.60.0/24
+
+Resources:
+
+  # DeletionPolicy prevents removal of white listed IP
+  ElasticIPAddressA:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: VPC
+
+  ElasticIPAddressB:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: VPC
+
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCIDR
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+      - Key: Name
+        Value:  !Ref "AWS::StackName"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: Vpc
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Ref PublicSubnetACIDR
+      AvailabilityZone: !Select [ 0, !GetAZs ]    # Get the first AZ in the list
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-PublicA
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Ref PublicSubnetBCIDR
+      AvailabilityZone: !Select [ 1, !GetAZs ]    # Get the second AZ in the list
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-PublicB
+
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Ref PrivateSubnetACIDR
+      AvailabilityZone: !Select [ 0, !GetAZs ]    # Get the first AZ in the list
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-PrivateA
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Ref PrivateSubnetBCIDR
+      AvailabilityZone: !Select [ 1, !GetAZs ]    # Get the second AZ in the list
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-PrivateB
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+      - Key: Name
+        Value: Public
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PrivateRouteTableA:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+      - Key: Name
+        Value: Private
+
+  PrivateRouteTableB:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: Private
+
+  PrivateRouteA:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableA
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NATGatewayA
+
+  PrivateRouteB:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableB
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NATGatewayB
+
+  NATGatewayA:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt ElasticIPAddressA.AllocationId
+      SubnetId: !Ref PublicSubnetA
+      Tags:
+      - Key: Name
+        Value: !Sub NAT-${AWS::StackName}
+
+  NATGatewayB:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt ElasticIPAddressB.AllocationId
+      SubnetId: !Ref PublicSubnetB
+      Tags:
+      - Key: Name
+        Value: !Sub NAT-${AWS::StackName}
+
+  PublicSubnetRouteTableAssociationA:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetA
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetRouteTableAssociationB:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetB
+      RouteTableId: !Ref PublicRouteTable
+
+  PrivateSubnetRouteTableAssociationA:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetA
+      RouteTableId: !Ref PrivateRouteTableA
+
+  PrivateSubnetRouteTableAssociationB:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetB
+      RouteTableId: !Ref PrivateRouteTableB
+
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow lambda to access resources
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: "GroupName"
+          Value: "lambda-vpc-sg"
+
+  VpcLink:
+    Type: AWS::ApiGatewayV2::VpcLink
+    Properties:
+      Name: ApiGatewayLinkToPrivateSubnets
+      SubnetIds:
+        - !Ref PrivateSubnetA
+      Tags:
+        Name: !Sub "${AWS::StackName}-VpcLink"
+
+  AwsServicesEndpointSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security Group to access AWS services via VPC endpoints
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: "Name"
+          Value: !Sub "${AWS::StackName}-AwsServicesEndpointSecurityGroup"
+        - Key: "Service"
+          Value: "ci/cd"
+
+  AwsServicesEndpointSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Allow traffic from containers on port 443
+      GroupId: !GetAtt AwsServicesEndpointSecurityGroup.GroupId
+      CidrIp: !GetAtt Vpc.CidrBlock
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  LambdaApiEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      ServiceName: !Sub "com.amazonaws.${AWS::Region}.lambda"
+      SecurityGroupIds:
+        - !GetAtt AwsServicesEndpointSecurityGroup.GroupId
+      SubnetIds:
+        - !Ref PrivateSubnetA
+      VpcEndpointType: Interface
+      VpcId: !Ref Vpc
+      PrivateDnsEnabled: true
+
+Outputs:
+
+  VpcId:
+    Description: A reference to the created Vpc
+    Value: !Ref Vpc
+    Export:
+      Name: !Sub ${AWS::StackName}-VpcId
+
+  PrivateSubnets:
+    Description: A list of the private subnets
+    Value: !Join [ ",",  [ !Ref PrivateSubnetA, !Ref PrivateSubnetB ] ]
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateSubnets
+
+  PrivateSubnetIdA:
+    Description: A reference to the private subnet in the 1st Availability Zone
+    Value: !GetAtt ["PrivateSubnetA", "SubnetId" ]
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateSubnetIdA
+
+  PrivateSubnetIdB:
+    Description: A reference to the private subnet in the 2nd Availability Zone
+    Value: !GetAtt [ "PrivateSubnetB", "SubnetId" ]
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateSubnetIdB
+
+  LambdaSecurityGroup:
+    Description: Security group for lambda
+    Value: !Ref LambdaSecurityGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-LambdaSecurityGroup
+
+  VpcLinkId:
+    Description: VPC Link for lambda and/or fargate
+    Value: !Ref VpcLink
+    Export:
+      Name: !Sub ${AWS::StackName}-VpcLinkId


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Add VPC for the address CRI to be used by the Fargate and Lambda deployments

### Why did it change

To enable the frontend Fargate deployments to be located in a VPC. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [398-XXX](https://govukverify.atlassian.net/browse/KBV-398)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [X] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->


### Other considerations

None
