### PR TITLE
OJ-892 - deploy core and txma infrastructure to POC

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_core_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -22,6 +22,9 @@ jobs:
           - target: KBV_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: KBV_POC
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to dev
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -23,6 +23,9 @@ jobs:
           - target: KBV_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: KBV_POC
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Core secrets for dev environments:
 | FRAUD_DEV_CORE_GH_ACTIONS_ROLE_ARN           | Assumed role IAM ARN |
 | KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME     | Upload artifact bucket |
 | KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN             | Assumed role IAM ARN |
+| KBV_POC_CORE_ARTIFACT_SOURCE_BUCKET_NAME     | Upload artifact bucket |
+| KBV_POC_CORE_GH_ACTIONS_ROLE_ARN             | Assumed role IAM ARN |
 
 Core secrets for Build environments:
 
@@ -44,6 +46,8 @@ TxMA secrets for dev environments:
 | FRAUD_DEV_TXMA_GH_ACTIONS_ROLE_ARN           | Assumed role IAM ARN |
 | KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME     | Upload artifact bucket |
 | KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN             | Assumed role IAM ARN |
+| KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME     | Upload artifact bucket |
+| KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN             | Assumed role IAM ARN |
 
 TxMA secrets for Build environments:
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added Github workflow deployment configurations for the core and txma infrastructure to push to the POC account.

### Why did it change

The core and txma infrastructure is required in the POC environment to support the common and other CRI's and so deployment workflow updates and repository secrets are needed to support the development and testing.
 
### Issue tracking

- [OJ-892](https://govukverify.atlassian.net/browse/OJ-892)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)
- [X] Added to the repository secrets

### Other considerations

The matrix deployment will push to all environments but will not change already deployed configurations however this PR should NOT be merged until after the live event.