### PR TITLE
LIME-131 Add UK Passport to core and txma matrixes

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_core_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, UK_PASSPORT_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -25,6 +25,9 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_CORE_GH_ACTIONS_ROLE_ARN
+          - target: UK_PASSPORT_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: UK_PASSPORT_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: UK_PASSPORT_DEV_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to dev
     runs-on: ubuntu-latest
@@ -71,7 +74,7 @@ jobs:
     needs: publish_core_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, UK_PASSPORT_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -82,6 +85,9 @@ jobs:
           - target: KBV_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    KBV_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: UK_PASSPORT_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: UK_PASSPORT_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:    UK_PASSPORT_BUILD_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to build
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, UK_PASSPORT_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -26,6 +26,9 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: UK_PASSPORT_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: UK_PASSPORT_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: UK_PASSPORT_DEV_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest
@@ -72,7 +75,7 @@ jobs:
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, UK_PASSPORT_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -83,6 +86,9 @@ jobs:
           - target: KBV_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET:    KBV_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: UK_PASSPORT_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: UK_PASSPORT_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:    UK_PASSPORT_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

### What changed

Add UK Passport CRI to each matrix.

### Why did it change

As part of Passport conversion, passport will switch to using the common stacks.

### Issue tracking

- [LIME-131](https://govukverify.atlassian.net/browse/LIME-131)
- [LIME-109](https://govukverify.atlassian.net/browse/LIME-109)
