### PR TITLE
LIME-160: Removed dev until a dev environment can be added for DL

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_core_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, DL_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -25,9 +25,6 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_CORE_GH_ACTIONS_ROLE_ARN
-          - target: DL_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to dev
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, DL_DEV ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -26,9 +26,6 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: DL_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the Driving Licence from common infra dev 

### Why did it change

Because DL does not have a distinct development environment

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-160](https://govukverify.atlassian.net/browse/LIME-160)
