### PR TITLE
OJ-1002 feat: SNS topic and subscription for sending alerts

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -113,6 +113,33 @@ Resources:
       Description: Api key 2
       Enabled: true
 
+  AlarmTopic:
+    Type: AWS::SNS::Topic
+
+  AlarmTopicSubscriptionPagerDuty:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref AlarmTopic
+      Endpoint: !Sub '{{resolve:ssm:/alerting/pagerduty/url}}'
+      Protocol: https
+
+  AlarmPublishToTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref AlarmTopic
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sns:Publish
+            Resource: !Ref AlarmTopic
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Condition:
+              ArnLike:
+                AWS:SourceArn: !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:*
+
 Outputs:
 
   TableNameSession1:
@@ -156,3 +183,9 @@ Outputs:
     Value: !Ref ApiKey2
     Export:
       Name: !Sub ${AWS::StackName}-ApiKey2
+
+  AlarmTopic:
+    Description: "Alarm SNS Topic"
+    Value: !Ref AlarmTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-AlarmTopic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Add infrastructure to support CloudWatch Alarms sending events to SNS.

### What changed

Add an SNS Topic and a pagerduty subscriber to the topic. Export the Topic Arn to be used by dependent stacks.

🚨 Each affected AWS account will need to have the SSM param `/alerting/pagerduty/url` set prior to deploying this stack.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1002](https://govukverify.atlassian.net/browse/OJ-1002)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
