### PR TITLE
F2F-135: Adding the CIC CRI to the GitHub workflows

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_core_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -25,6 +25,9 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_CORE_GH_ACTIONS_ROLE_ARN
+          - target: CIC_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to dev
     runs-on: ubuntu-latest
@@ -71,7 +74,7 @@ jobs:
     needs: publish_core_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -85,6 +88,9 @@ jobs:
           - target: DL_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: CIC_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_BUILD_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to build
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, FRAUD_DEV, KBV_DEV, KBV_POC, CIC_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -26,6 +26,9 @@ jobs:
           - target: KBV_POC
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: CIC_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest
@@ -72,7 +75,7 @@ jobs:
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -86,6 +89,9 @@ jobs:
           - target: DL_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: CIC_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to build
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,58 +168,86 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "ac904d389254fffc7cc27a4ec21fca7f71d17f81",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "d01a3f52f7d39e6cac709b097e829721bcef4eea",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
-        "is_verified": false,
-        "line_number": 77
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
-        "is_verified": false,
-        "line_number": 78
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
         "line_number": 80
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
+        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
         "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
+        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
         "line_number": 83
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
+        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
         "line_number": 84
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
+        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
         "is_verified": false,
         "line_number": 86
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
+        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
         "is_verified": false,
         "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
+        "is_verified": false,
+        "line_number": 89
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "998f949c48369fecb8e0dd716c9ea33b4592fb4e",
+        "is_verified": false,
+        "line_number": 92
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "09a43bc6cec279eb0fee54a9cd8ffd53dd82de8b",
+        "is_verified": false,
+        "line_number": 93
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [
@@ -282,60 +310,88 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "8d4ef2d3229df50b0119f14e10625e22a8300e62",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "0ce609d0bb3d202ec796de3a376c0bd45ddf2ede",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
-        "is_verified": false,
-        "line_number": 78
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
-        "is_verified": false,
-        "line_number": 79
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
         "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
+        "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
         "line_number": 82
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
+        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
         "line_number": 84
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
+        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
         "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
+        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
         "is_verified": false,
         "line_number": 87
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
+        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
         "is_verified": false,
         "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "9647662c4b867d5049aa78b1db20e55cacd3c542",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "71c9f5540bc9f46e6a971acd22e62cff33e58b64",
+        "is_verified": false,
+        "line_number": 94
       }
     ]
   },
-  "generated_at": "2022-11-08T10:17:52Z"
+  "generated_at": "2022-12-07T14:18:13Z"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The CIC CRI is added to the list of CRIs in the GitHub post-merge-publish-core-infrastructure workflow and the post-merge-publish-txma-infrastructure workflow. 

New secrets are referenced, which will need to be added to this repo. 

### Why did it change

New CRI needed to be added to common infrastructure workflows.

### Issue tracking

[F2F-135](https://govukverify.atlassian.net/browse/F2F-135)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
