### PR TITLE
F2F-138: Added steps to populate artifact bucket with required metadata.

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -130,4 +130,6 @@ jobs:
       - name: Upload zipped CloudFormation artifact to S3
         env:
           ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
+        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip" \
+              --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA" 
+              

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -131,4 +131,5 @@ jobs:
       - name: Upload zipped CloudFormation artifact to S3
         env:
           ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
+        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip" \
+               --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA" 


### PR DESCRIPTION
Added code to 'Upload zipped CloudFormation artifact to S3' step of 'Publish txma infrastructure to build' job to add requited metadata to the artifact bucket.

[F2F-138](https://govukverify.atlassian.net/browse/F2F-138)

## Proposed changes

### What changed

Added a line copied from [dev platforms action](https://github.com/alphagov/di-devplatform-upload-action/blob/main/scripts/upload.sh)  in order to add metadata.

### Why did it change

Our build was failing due to missing metadata.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXX](https://govukverify.atlassian.net/browse/OJ-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
