### PR TITLE
Set ownership to di-ipv-orange-cri-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-ipv
+* @alphagov/di-ipv-orange-cri-maintainers


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

Set CODEOWNER of the repository to the Orange CRI team. 

This will:
- help to more clearly define ownership
- enable use of tooling around Orange CRI team specifics, as opposed to all of IPV
 
<!-- Describe the reason these changes were made - the "why" -->
