### PR TITLE
PLAT-811: Passport CRI in post-merge GHA

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -11,7 +11,7 @@ jobs:
   publish_core_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV ]
+        target: [ ADDRESS_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV, PASSPORTA_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -28,6 +28,9 @@ jobs:
           - target: DL_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORTA_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to dev
     runs-on: ubuntu-latest
@@ -81,7 +84,7 @@ jobs:
     needs: publish_core_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD, PASSPORTA_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
@@ -98,6 +101,9 @@ jobs:
           - target: CIC_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: CIC_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORTA_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_CORE_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish core infrastructure to build
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV ]
+        target: [ ADDRESS_DEV, KBV_DEV, KBV_POC, CIC_DEV, DL_DEV, PASSPORTA_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -29,6 +29,9 @@ jobs:
           - target: DL_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORTA_DEV
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest
@@ -82,7 +85,7 @@ jobs:
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, CIC_BUILD, PASSPORTA_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -99,6 +102,9 @@ jobs:
           - target: CIC_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: CIC_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORTA_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to build
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -182,72 +182,100 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "e959bfefa7dc9de9d4a01b35b2fe4f0c8ea48414",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "9deae82cb991c2f4529712299a87e485ee62fe8b",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
-        "is_verified": false,
-        "line_number": 87
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
-        "is_verified": false,
-        "line_number": 88
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
         "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
+        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
         "line_number": 91
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
+        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
         "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
+        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
         "line_number": 94
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
+        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
         "is_verified": false,
         "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
+        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
         "is_verified": false,
         "line_number": 97
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "998f949c48369fecb8e0dd716c9ea33b4592fb4e",
+        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
         "is_verified": false,
         "line_number": 99
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "09a43bc6cec279eb0fee54a9cd8ffd53dd82de8b",
+        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
         "is_verified": false,
         "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "998f949c48369fecb8e0dd716c9ea33b4592fb4e",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "09a43bc6cec279eb0fee54a9cd8ffd53dd82de8b",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
+        "is_verified": false,
+        "line_number": 106
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [
@@ -324,74 +352,102 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "5d7249cd1f6dc6065f470d761cf7093ef116ff54",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "72334fd6074dc6ea1e1f5b7701507c537eff6e4a",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
-        "is_verified": false,
-        "line_number": 88
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
-        "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
         "line_number": 91
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
+        "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
         "line_number": 92
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
+        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
         "line_number": 94
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
+        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
         "line_number": 95
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
+        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
         "is_verified": false,
         "line_number": 97
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
+        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
         "is_verified": false,
         "line_number": 98
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "9647662c4b867d5049aa78b1db20e55cacd3c542",
+        "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
         "is_verified": false,
         "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "71c9f5540bc9f46e6a971acd22e62cff33e58b64",
+        "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
         "is_verified": false,
         "line_number": 101
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "9647662c4b867d5049aa78b1db20e55cacd3c542",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "71c9f5540bc9f46e6a971acd22e62cff33e58b64",
+        "is_verified": false,
+        "line_number": 104
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
+        "is_verified": false,
+        "line_number": 107
       }
     ]
   },
-  "generated_at": "2023-03-07T09:56:42Z"
+  "generated_at": "2023-03-08T17:48:45Z"
 }


### PR DESCRIPTION
## Proposed changes

Passport CRI DEV and BUILD deployments configurations added to post-merge action

### Why did it change

To align passport CRI with common-cri best practices

### Issue tracking

- [PLAT-811](https://govukverify.atlassian.net/browse/PLAT-811)

### Environment variables or secrets

Secure pipeline secrets similar to existing CRIs 

[PLAT-811]: https://govukverify.atlassian.net/browse/PLAT-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ