### PR TITLE
Update txma matrix to use dev-platform upload action

### DIFF
--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
   publish_txma_to_matrix_dev:
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, KBV_DEV, DL_DEV, PASSPORTA_DEV, TOY_DEV, KBV_POC ]
+        target: [ ADDRESS_DEV, KBV_DEV, DL_DEV, PASSPORTA_DEV, TOY_DEV ]
         include:
           - target: ADDRESS_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -29,9 +29,6 @@ jobs:
           - target: TOY_DEV
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: KBV_POC
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_POC_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_POC_TXMA_GH_ACTIONS_ROLE_ARN
 
       max-parallel: 2
     name: Publish txma infrastructure to dev
@@ -64,29 +61,18 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t txma/template.yaml
 
-      - name: SAM build
-        run: sam build -t txma/template.yaml
-
-      - name: SAM package
-        run: |
-          sam package -t txma/template.yaml  \
-            --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
-
-      - name: Zip the CloudFormation template
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        env:
-          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
-
+      - name: Deploy SAM template
+        uses: alphagov/di-devplatform-upload-action@v3.2
+        with:
+            artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
+            signing-profile-name: ""
+            working-directory: ./txma
 
   publish_txma_to_matrix_build:
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD ]
+        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD, TOY_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
@@ -103,6 +89,9 @@ jobs:
           - target: PASSPORTA_BUILD
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: TOY_BUILD
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: TOY_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
       max-parallel: 2
     name: Publish txma infrastructure to build
     runs-on: ubuntu-latest
@@ -134,19 +123,9 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t txma/template.yaml
 
-      - name: SAM build
-        run: sam build -t txma/template.yaml
-
-      - name: SAM package
-        run: |
-          sam package -t txma/template.yaml  \
-            --s3-bucket ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
-
-      - name: Zip the CloudFormation template
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        env:
-          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-        run: aws s3 cp template.zip "s3://${{ env.ARTIFACT_SOURCE_BUCKET_NAME }}/template.zip"
+      - name: Deploy SAM template
+        uses: alphagov/di-devplatform-upload-action@v3.2
+        with:
+            artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
+            signing-profile-name: ""
+            working-directory: ./txma

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,88 +324,88 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "489624aa3804310f43a8c6f2e4053e03977627b9",
-        "is_verified": false,
-        "line_number": 33
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "390c92a2b2d58508cb493c081aed676b9fc4ff03",
-        "is_verified": false,
-        "line_number": 34
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 78
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 81
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 82
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 84
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 87
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 88
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "7979a6fea9efaa3e78be5d23c5eb82cd64e48921",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "9b997018ecbc31bd3133c9d26621ef27dc0a02ca",
+        "is_verified": false,
+        "line_number": 94
       }
     ]
   },
-  "generated_at": "2023-04-20T10:31:48Z"
+  "generated_at": "2023-05-03T18:16:48Z"
 }


### PR DESCRIPTION

## Proposed changes

### What changed

Added toy build to the workflow
Updated txma matrix to use dev-platform upload action

### Why did it change

This change brings in the metadata for Grafana and other tooling

### Issue tracking

- [OJ-1518](https://govukverify.atlassian.net/browse/OJ-1518)
- [OJ-1521](https://govukverify.atlassian.net/browse/OJ-1521)

## Checklists

### Environment variables or secrets

- [ ] Documented in the [README](./blob/main/README.md)
- [X] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1518]: https://govukverify.atlassian.net/browse/OJ-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-1521]: https://govukverify.atlassian.net/browse/OJ-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ