### PR TITLE
OJ-1663 enable root account access for audit queue consumers

### DIFF
--- a/txma/template.yaml
+++ b/txma/template.yaml
@@ -21,11 +21,15 @@ Parameters:
   PermissionsBoundary:
     Type: String
 
+Conditions:
+  IsProdLikeEnvironment: !Or
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+    - !Equals [ !Ref Environment, production ]
+
 Mappings:
   TxMARootMapping:
     Environment:
-      dev: "arn:aws:iam::178023842775:root"
-      build: "arn:aws:iam::178023842775:root"
       staging: "arn:aws:iam::178023842775:root"
       integration: "arn:aws:iam::729485541398:root"
       production: "arn:aws:iam::451773080033:root"
@@ -61,7 +65,17 @@ Resources:
         - !Ref AuditEventQueue
       PolicyDocument:
         Statement:
+          - Sid: "EnableRootMessageAccess"
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - "sqs:ReceiveMessage"
+              - "sqs:DeleteMessage"
+              - "sqs:GetQueueAttributes"
+            Resource: !GetAtt AuditEventQueue.Arn
           - Sid: "AllowReadByTXMAAccount"
+            Condition: IsProdLikeEnvironment
             Effect: Allow
             Principal:
               AWS: !FindInMap [TxMARootMapping, Environment, !Ref 'Environment']


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Allow each account to consume messages from their own txma audit event queue

### Why did it change

To prevent txma from being overwhelmed by messages when performance testing of the CRIs begins, we've created a lambda to consume the messages however this lambda needs permission to do so

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1663](https://govukverify.atlassian.net/browse/OJ-1663)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[OJ-1663]: https://govukverify.atlassian.net/browse/OJ-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ