### PR TITLE
oj-1839 hmrc txma and core matrix builds plus enablement toggles

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -9,33 +9,45 @@ on:
 
 jobs:
   publish_core_to_matrix_dev:
+    name: Publish core to ${{ matrix.target }} dev
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, KBV_DEV, TOY_DEV, DL_DEV, PASSPORTA_DEV, HMRC_KBV_DEV, HMRC_CHECK_DEV ]
+        target: [ ADDRESS_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, TOY_DEV ]
         include:
           - target: ADDRESS_DEV
+            ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: ADDRESS_DEV_CORE_GH_ACTIONS_ROLE_ARN
-          - target: KBV_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN
-          - target: TOY_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_CORE_GH_ACTIONS_ROLE_ARN
           - target: DL_DEV
+            ENABLED: "${{ vars.DL_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_CORE_GH_ACTIONS_ROLE_ARN
-          - target: PASSPORTA_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_CORE_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_KBV_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: FRAUD_DEV
+            ENABLED: "${{ vars.FRAUD_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_DEV_CORE_GH_ACTIONS_ROLE_ARN
           - target: HMRC_CHECK_DEV
+            ENABLED: "${{ vars.HMRC_CHECK_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_DEV_CORE_GH_ACTIONS_ROLE_ARN
-      max-parallel: 2
-    name: Publish core infrastructure to dev
+          - target: HMRC_KBV_DEV
+            ENABLED: "${{ vars.HMRC_KBV_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: KBV_DEV
+            ENABLED: "${{ vars.KBV_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORT_DEV
+            ENABLED: "${{ vars.PASSPORT_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: TOY_DEV
+            ENABLED: "${{ vars.TOY_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_CORE_GH_ACTIONS_ROLE_ARN
+
+
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -44,67 +56,86 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
         with:
           version: 1.74.0
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml
 
       - name: Deploy SAM template
+        if: matrix.ENABLED == 'true'
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
             signing-profile-name: ""
             working-directory: ./core
+
+      - name: Inform of disabled status
+        if: matrix.ENABLED != 'true'
+        run: echo "🔶 Set repository variable ${{ matrix.target }}_ENABLED to 'true' to enable	🔶" >> $GITHUB_STEP_SUMMARY
 
 
   publish_core_to_matrix_build:
+    name: Publish core to ${{ matrix.target }} build
     needs: publish_core_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD, TOY_BUILD, HMRC_KBV_BUILD, HMRC_CHECK_BUILD ]
+        target: [ ADDRESS_BUILD, DL_BUILD, FRAUD_BUILD, HMRC_CHECK_BUILD, HMRC_KBV_BUILD, KBV_BUILD, PASSPORT_BUILD, TOY_BUILD ]
         include:
           - target: ADDRESS_BUILD
+            ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: ADDRESS_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-          - target: FRAUD_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-          - target: KBV_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_BUILD_CORE_GH_ACTIONS_ROLE_ARN
           - target: DL_BUILD
+            ENABLED: "${{ vars.DL_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-          - target: PASSPORTA_BUILD
+          - target: FRAUD_BUILD
+            ENABLED: "${{ vars.FRAUD_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_CHECK_BUILD
+            ENABLED: "${{ vars.HMRC_CHECK_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_KBV_BUILD
+            ENABLED: "${{ vars.HMRC_KBV_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: KBV_BUILD
+            ENABLED: "${{ vars.KBV_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_BUILD_CORE_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORT_BUILD
+            ENABLED: "${{ vars.PASSPORT_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_CORE_GH_ACTIONS_ROLE_ARN
           - target: TOY_BUILD
+            ENABLED: "${{ vars.TOY_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: TOY_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_KBV_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_CHECK_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_BUILD_CORE_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_BUILD_CORE_GH_ACTIONS_ROLE_ARN
-      max-parallel: 2
-    name: Publish core infrastructure to build
+
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -113,32 +144,42 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
         with:
           version: 1.74.0
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml
 
+
       - name: Deploy SAM template
+        if: matrix.ENABLED == 'true'
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
             signing-profile-name: ""
             working-directory: ./core
 
-
+      - name: Inform of disabled status
+        if: matrix.ENABLED != 'true'
+        run: echo "🔶 Set repository variable ${{ matrix.target }}_ENABLED to 'true' to enable	🔶" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -10,34 +10,44 @@ on:
 
 jobs:
   publish_txma_to_matrix_dev:
+    name: Publish txma to ${{ matrix.target }} dev
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, KBV_DEV, DL_DEV, PASSPORTA_DEV, TOY_DEV, HMRC_KBV_DEV, HMRC_CHECK_DEV ]
+        target: [ ADDRESS_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, TOY_DEV ]
         include:
           - target: ADDRESS_DEV
+            ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: ADDRESS_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: KBV_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN
           - target: DL_DEV
+            ENABLED: "${{ vars.DL_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: PASSPORTA_DEV
+          - target: FRAUD_DEV
+            ENABLED: "${{ vars.FRAUD_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET:         FRAUD_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_CHECK_DEV
+            ENABLED: "${{ vars.HMRC_CHECK_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_KBV_DEV
+            ENABLED: "${{ vars.HMRC_KBV_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: KBV_DEV
+            ENABLED: "${{ vars.KBV_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORT_DEV
+            ENABLED: "${{ vars.PASSPORT_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_TXMA_GH_ACTIONS_ROLE_ARN
           - target: TOY_DEV
+            ENABLED: "${{ vars.TOY_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_KBV_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_CHECK_DEV
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_DEV_TXMA_GH_ACTIONS_ROLE_ARN
 
-      max-parallel: 2
-    name: Publish txma infrastructure to dev
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -46,66 +56,86 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
         with:
           version: 1.74.0
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t txma/template.yaml
 
       - name: Deploy SAM template
+        if: matrix.ENABLED == 'true'
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
             signing-profile-name: ""
             working-directory: ./txma
 
+      - name: Inform of disabled status
+        if: matrix.ENABLED != 'true'
+        run: echo "🔶 Set repository variable ${{ matrix.target }}_ENABLED to 'true' to enable	🔶" >> $GITHUB_STEP_SUMMARY
+
   publish_txma_to_matrix_build:
+    name: Publish txma to ${{ matrix.target }} build
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, FRAUD_BUILD, KBV_BUILD, DL_BUILD, PASSPORTA_BUILD, TOY_BUILD, HMRC_KBV_BUILD, HMRC_CHECK_BUILD ]
+        target: [ ADDRESS_BUILD, DL_BUILD, FRAUD_BUILD, HMRC_CHECK_BUILD, HMRC_KBV_BUILD, KBV_BUILD, PASSPORT_BUILD, TOY_BUILD ]
         include:
           - target: ADDRESS_BUILD
+            ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: ADDRESS_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: ADDRESS_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: FRAUD_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: KBV_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: KBV_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
           - target: DL_BUILD
+            ENABLED: "${{ vars.DL_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: DL_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: DL_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: PASSPORTA_BUILD
+          - target: FRAUD_BUILD
+            ENABLED: "${{ vars.FRAUD_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: FRAUD_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: FRAUD_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_CHECK_BUILD
+            ENABLED: "${{ vars.HMRC_CHECK_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: HMRC_KBV_BUILD
+            ENABLED: "${{ vars.HMRC_KBV_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: KBV_BUILD
+            ENABLED: "${{ vars.KBV_BUILD_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: KBV_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: KBV_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
+          - target: PASSPORT_BUILD
+            ENABLED: "${{ vars.PASSPORT_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
           - target: TOY_BUILD
+            ENABLED: "${{ vars.TOY_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: TOY_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_KBV_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_KBV_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_KBV_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: HMRC_CHECK_BUILD
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: HMRC_CHECK_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: HMRC_CHECK_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-      max-parallel: 2
-    name: Publish txma infrastructure to build
+
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -114,30 +144,41 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        if: matrix.ENABLED == 'true'
+        uses: actions/checkout@v3
 
       - name: Setup Python
+        if: matrix.ENABLED == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.2
 
       - name: Setup SAM
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/setup-sam@v2
         with:
           version: 1.74.0
 
       - name: Assume temporary AWS role
+        if: matrix.ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
+        if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t txma/template.yaml
 
       - name: Deploy SAM template
+        if: matrix.ENABLED == 'true'
         uses: alphagov/di-devplatform-upload-action@v3.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
             signing-profile-name: ""
             working-directory: ./txma
+
+      - name: Inform of disabled status
+        if: matrix.ENABLED != 'true'
+        run: echo "🔶 Set repository variable ${{ matrix.target }}_ENABLED to 'true' to enable	🔶" >> $GITHUB_STEP_SUMMARY

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,210 +114,224 @@
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "f555b8b7a93dd8bb8d31a74f62be538851b0f9f1",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 19
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "006202d6e6394bb7151c39053189ce028172b28d",
         "is_verified": false,
-        "line_number": 18
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "48554134b06ac14ccfabce8e48461579af547db0",
-        "is_verified": false,
         "line_number": 20
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "ad5f0a29d30d5ee60c2e291b4bd1f9ffa22c5bea",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "705357aa5611bf50ca0f1a7a5a22f96b98cb5197",
-        "is_verified": false,
-        "line_number": 23
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "5f23a97cb1191c12faa8a56242b0f26c4d2eae76",
-        "is_verified": false,
-        "line_number": 24
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "15c1a36e0b8d2856f84b28198d9c271e259018da",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "3b447b2b970b3fa8b194970d95de8322a8f92d3b",
         "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "3c9195fc6a5ee030d6483eab463f8319d49c0811",
+        "is_verified": false,
         "line_number": 27
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "e959bfefa7dc9de9d4a01b35b2fe4f0c8ea48414",
+        "hashed_secret": "4b5396320488f7f35b90e23dfc4b55aef695b07d",
         "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "9deae82cb991c2f4529712299a87e485ee62fe8b",
-        "is_verified": false,
-        "line_number": 30
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "98cb0b22bae9a1e9e8f965b7221f0cad92ccc713",
-        "is_verified": false,
-        "line_number": 32
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "46faa494579d521cb49c043d38a8bbb3617d55e6",
-        "is_verified": false,
-        "line_number": 33
+        "line_number": 28
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "53b66139c757af44e876b73144462770ac1a89d4",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "8586ef52076dab450b948e85f7d054f3ba3ee696",
         "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "98cb0b22bae9a1e9e8f965b7221f0cad92ccc713",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "46faa494579d521cb49c043d38a8bbb3617d55e6",
+        "is_verified": false,
         "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "48554134b06ac14ccfabce8e48461579af547db0",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "ad5f0a29d30d5ee60c2e291b4bd1f9ffa22c5bea",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "e959bfefa7dc9de9d4a01b35b2fe4f0c8ea48414",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "9deae82cb991c2f4529712299a87e485ee62fe8b",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "705357aa5611bf50ca0f1a7a5a22f96b98cb5197",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "5f23a97cb1191c12faa8a56242b0f26c4d2eae76",
+        "is_verified": false,
+        "line_number": 48
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
-        "line_number": 84
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
-        "is_verified": false,
-        "line_number": 86
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
-        "is_verified": false,
-        "line_number": 87
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
-        "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
-        "is_verified": false,
-        "line_number": 90
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 112
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
+        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
+        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
-        "line_number": 96
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "a44d5f4bc98a021a65426af87c031e48f39a6cf1",
-        "is_verified": false,
-        "line_number": 98
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "a22d3f61c7271cbc04c0f2cf5cf6838348ce64ff",
-        "is_verified": false,
-        "line_number": 99
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
-        "is_verified": false,
-        "line_number": 101
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
-        "is_verified": false,
-        "line_number": 102
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "9a166e92ce6c68701ca855ecfd9cb3fef530cb1e",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 120
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "f69a767cf13cc0bb7f0d2566554e012d7e1cf34c",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
+        "is_verified": false,
+        "line_number": 124
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
+        "is_verified": false,
+        "line_number": 129
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
+        "is_verified": false,
+        "line_number": 132
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "a44d5f4bc98a021a65426af87c031e48f39a6cf1",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "a22d3f61c7271cbc04c0f2cf5cf6838348ce64ff",
+        "is_verified": false,
+        "line_number": 137
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [
@@ -326,28 +340,14 @@
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3be6dc7ff476bcc2246bb3e0ec67fca4dcb4385f",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "514dbf9b8c7b4d902f0d7cac8473f6f93bddca09",
         "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "804be0728d473fb1c4a93202471b894ed3cb38f9",
-        "is_verified": false,
         "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "d2a0ddcfe1bdc5b25e21605f8d420198f8a3c4a6",
-        "is_verified": false,
-        "line_number": 22
       },
       {
         "type": "Secret Keyword",
@@ -366,172 +366,200 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "5d7249cd1f6dc6065f470d761cf7093ef116ff54",
-        "is_verified": false,
-        "line_number": 27
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "72334fd6074dc6ea1e1f5b7701507c537eff6e4a",
+        "hashed_secret": "0d9b7e72bba388299193d7184f92ba32179f00ff",
         "is_verified": false,
         "line_number": 28
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "b089b063c6d9c53c5aae02638908c0c2fc722119",
+        "hashed_secret": "3f820b09a33de758ac53fbb6d27c843992d5911b",
         "is_verified": false,
-        "line_number": 30
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "1b81bb8d0323538a63dffdead9bf30c350195c95",
-        "is_verified": false,
-        "line_number": 31
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "2efa06b0151f90b6ddaa0a96591bea75e86b84f2",
-        "is_verified": false,
-        "line_number": 33
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "cfe8086e3f5b04c6c66f0c95d723fa940574452a",
-        "is_verified": false,
-        "line_number": 34
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "5cfc4f382dc5af20f47c92a5b624c2e003f9cc9a",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "f1ad8cbba34ba220150b39a58950cbdd54b6990b",
         "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "2efa06b0151f90b6ddaa0a96591bea75e86b84f2",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "cfe8086e3f5b04c6c66f0c95d723fa940574452a",
+        "is_verified": false,
         "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "804be0728d473fb1c4a93202471b894ed3cb38f9",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "d2a0ddcfe1bdc5b25e21605f8d420198f8a3c4a6",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "5d7249cd1f6dc6065f470d761cf7093ef116ff54",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "72334fd6074dc6ea1e1f5b7701507c537eff6e4a",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "b089b063c6d9c53c5aae02638908c0c2fc722119",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "1b81bb8d0323538a63dffdead9bf30c350195c95",
+        "is_verified": false,
+        "line_number": 49
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
-        "is_verified": false,
-        "line_number": 87
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
-        "is_verified": false,
-        "line_number": 88
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
-        "is_verified": false,
-        "line_number": 90
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
-        "is_verified": false,
-        "line_number": 91
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 112
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
+        "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
+        "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
-        "line_number": 97
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "7979a6fea9efaa3e78be5d23c5eb82cd64e48921",
-        "is_verified": false,
-        "line_number": 99
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "9b997018ecbc31bd3133c9d26621ef27dc0a02ca",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "a4f084569a90bdd02134f5367ee35f4d20a47cd1",
-        "is_verified": false,
-        "line_number": 102
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "3f632b9676f0c73235da0dfeae282d4b2160b471",
-        "is_verified": false,
-        "line_number": 103
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "644ed701db5143c463f179028dbc758861de6cf6",
         "is_verified": false,
-        "line_number": 105
+        "line_number": 120
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c5f66aeadfc064ab45381c470ec70d019aac7ead",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "a4f084569a90bdd02134f5367ee35f4d20a47cd1",
+        "is_verified": false,
+        "line_number": 124
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "3f632b9676f0c73235da0dfeae282d4b2160b471",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
+        "is_verified": false,
+        "line_number": 129
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
+        "is_verified": false,
+        "line_number": 132
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "7979a6fea9efaa3e78be5d23c5eb82cd64e48921",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
+        "hashed_secret": "9b997018ecbc31bd3133c9d26621ef27dc0a02ca",
+        "is_verified": false,
+        "line_number": 137
       }
     ]
   },
-  "generated_at": "2023-08-25T14:10:16Z"
+  "generated_at": "2023-09-15T17:59:59Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added configurations for HMRC
Added deployment enablement flags as repository variables
Re-added fraud which had gone missing from the dev deployments

### Why did it change

These changes allow deployment to specific targets and enable HMRC deployments for Dev and Build and re-introduce fraud dev.

### Issue tracking

- [OJ-1839](https://govukverify.atlassian.net/browse/OJ-1839)
- [OJ-1853](https://govukverify.atlassian.net/browse/OJ-1853)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1839]: https://govukverify.atlassian.net/browse/OJ-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-1853]: https://govukverify.atlassian.net/browse/OJ-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ